### PR TITLE
Add pip cache in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
           key: pip-cache-${{ hashFiles('requirements.txt') }}-${{ hashFiles('requirements-dev.txt') }}
 
       - name: Install dependencies
-        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt


### PR DESCRIPTION
# Description

Add pip cache in CI workflow to save time and money (later).

<!--
Please also use github reserved keywords to create link to existing issues.
Example: Closes #1234
Reference: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

# Checklist

- [x] descriptive PR title
- [ ] passes `pylint` locally
- [ ] adds related test cases
- [x] passes test cases locally
- [x] passes CI

Please strikethrough irrelevant items.
