### PR TITLE
Reduce docker image size by ~500M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM python:3.9
+FROM python:3.9-slim-buster
 
 LABEL maintainer="Cherry Ng <cherry92@gmail.com>"
+
+RUN apt-get update
+RUN apt-get -y install build-essential
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt


### PR DESCRIPTION
# Description

Use the `slim-buster` base image from python repository, and reduced ~500M in server image size.

<!--
Please also use github reserved keywords to create link to existing issues.
Example: Closes #1234
Reference: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

# Checklist

- [x] descriptive PR title
- [x] passes `pylint` locally
- [ ] adds related test cases
- [x] passes test cases locally
- [x] passes CI

Please strikethrough irrelevant items.
