### PR TITLE
Fix black and pylint hooks error when committing multiple python files.

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -11,12 +11,13 @@ fi
 
 commit_py_files="$(git diff --cached --name-only --diff-filter=d | grep "\.py$")"
 if [[ ! -z "${commit_py_files}" ]]; then
+  commit_py_files_array=(${commit_py_files})
   # Run black.
   echo "Running black ..."
-  black "${commit_py_files}"
+  black "${commit_py_files_array[@]}"
 
   # Run pylint.
   echo "Running pylint ..."
-  pylint "${commit_py_files}"
+  pylint "${commit_py_files_array[@]}"
 fi
 


### PR DESCRIPTION
# Description

Apparently #18 can only allow a single file because we didn't split the list of files into array before passing to `black` and `pylint`.

This fixes the issue and #20 is not needed.

<!--
Please also use github reserved keywords to create link to existing issues.
Example: Closes #1234
Reference: https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

# Checklist

- [x] descriptive PR title
- [x] passes `pylint` locally
- [ ] adds related test cases
- [x] passes test cases locally
- [x] passes CI

Please strikethrough irrelevant items.
